### PR TITLE
Correcting association name :location instead of :locations

### DIFF
--- a/lib/api/v1/widget_presenter.rb
+++ b/lib/api/v1/widget_presenter.rb
@@ -12,7 +12,7 @@ module Api
 
       # Optional filter that applies a lambda.
       filter :location_name do |scope, location_name|
-        scope.joins(:locations).where("locations.name = ?", location_name)
+        scope.joins(:location).where("locations.name = ?", location_name)
       end
 
       # Optional filter that applies a lambda.


### PR DESCRIPTION
I needed to singularize the association reference in order to get this url to work:

http://localhost:3000/api/v1/widgets?include=location&location_name=Hull

Or should I be using a different url?